### PR TITLE
Removed transactions from ModelCriteria methods.

### DIFF
--- a/runtime/lib/query/ModelCriteria.php
+++ b/runtime/lib/query/ModelCriteria.php
@@ -1649,17 +1649,11 @@ class ModelCriteria extends Criteria
         $criteria = $this->isKeepQuery() ? clone $this : $this;
         $criteria->setDbName($this->getDbName());
 
-        $con->beginTransaction();
-        try {
-            if (!$affectedRows = $criteria->basePreDelete($con)) {
-                $affectedRows = $criteria->doDelete($con);
-            }
-            $criteria->basePostDelete($affectedRows, $con);
-            $con->commit();
-        } catch (Exception $e) {
-            $con->rollback();
-            throw $e;
+        if (!$affectedRows = $criteria->basePreDelete($con)) {
+            $affectedRows = $criteria->doDelete($con);
         }
+
+        $criteria->basePostDelete($affectedRows, $con);
 
         return $affectedRows;
     }
@@ -1694,19 +1688,14 @@ class ModelCriteria extends Criteria
         if ($con === null) {
             $con = Propel::getConnection($this->getDbName(), Propel::CONNECTION_WRITE);
         }
-        $con->beginTransaction();
-        try {
-            if (!$affectedRows = $this->basePreDelete($con)) {
-                $affectedRows = $this->doDeleteAll($con);
-            }
-            $this->basePostDelete($affectedRows, $con);
-            $con->commit();
 
-            return $affectedRows;
-        } catch (Exception $e) {
-            $con->rollBack();
-            throw $e;
+        if (!$affectedRows = $this->basePreDelete($con)) {
+            $affectedRows = $this->doDeleteAll($con);
         }
+
+        $this->basePostDelete($affectedRows, $con);
+
+        return $affectedRows;
     }
 
     /**
@@ -1786,19 +1775,11 @@ class ModelCriteria extends Criteria
         $criteria = $this->isKeepQuery() ? clone $this : $this;
         $criteria->setPrimaryTableName(constant($this->modelPeerName . '::TABLE_NAME'));
 
-        $con->beginTransaction();
-        try {
-
-            if (!$affectedRows = $criteria->basePreUpdate($values, $con, $forceIndividualSaves)) {
-                $affectedRows = $criteria->doUpdate($values, $con, $forceIndividualSaves);
-            }
-            $criteria->basePostUpdate($affectedRows, $con);
-
-            $con->commit();
-        } catch (Exception $e) {
-            $con->rollBack();
-            throw $e;
+        if (!$affectedRows = $criteria->basePreUpdate($values, $con, $forceIndividualSaves)) {
+            $affectedRows = $criteria->doUpdate($values, $con, $forceIndividualSaves);
         }
+
+        $criteria->basePostUpdate($affectedRows, $con);
 
         return $affectedRows;
     }


### PR DESCRIPTION
Since nested transactions are removed in ae59d48e1135247b254e31cd6e75e8a4b990f4c2, this will cause a "There is already an active transaction" error.

Trust the application to manage the transaction.