### PR TITLE
Implement IteratorAggregate instead of (Seekable)Iterator

### DIFF
--- a/runtime/lib/collection/PropelCollection.php
+++ b/runtime/lib/collection/PropelCollection.php
@@ -25,7 +25,7 @@
  * @author     Francois Zaninotto
  * @package    propel.runtime.collection
  */
-class PropelCollection implements \ArrayAccess, \SeekableIterator, \Countable, \Serializable
+class PropelCollection implements \ArrayAccess, \Countable, \IteratorAggregate, \Serializable
 {
     /**
      * @var       string
@@ -45,6 +45,14 @@ class PropelCollection implements \ArrayAccess, \SeekableIterator, \Countable, \
     public function __construct($data = array())
     {
         $this->data = $data;
+    }
+
+    /**
+     * @return ArrayIterator
+     */
+    public function getIterator()
+    {
+        return new ArrayIterator($this->data);
     }
 
     /**


### PR DESCRIPTION
As the doctrine docs say:

> A Collection has an internal iterator just like a PHP array. In addition, a Collection can be iterated with external iterators, which is preferrable. To use an external iterator simply use the foreach language construct to iterate over the collection (which calls IteratorAggregate::getIterator() internally) or explicitly retrieve an iterator though IteratorAggregate::getIterator() which can then be used to iterate over the collection. You can not rely on the internal iterator of the collection being at a certain position unless you explicitly positioned it before. Prefer iteration with external iterators.